### PR TITLE
Persist data and default config problems solve it

### DIFF
--- a/cfg-data/config.json
+++ b/cfg-data/config.json
@@ -150,7 +150,7 @@
             "INFLUXDB": {
                 "type": "object",
                 "default": {
-                    "HOST": "http://influxdb",
+                    "HOST": "influxdb",
                     "PORT": "8086",
                     "ORG": "edge",
                     "BUCKET": "databus_values",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
     image: database_influxdb:2.6.1-alpine
     restart: unless-stopped
     volumes:
-      - data-storage:/var/lib/influxdb
+      - data-storage:/var/lib/influxdb2
     networks:
       - app-net
     ports:


### PR DESCRIPTION
The problem was that the data didn't persist when you stop the App, but now you can stop and restart the application inside the IED and the data inside the bucket persist from the installation.

The second problem is about the default configuration inside the config.json. The IP dir was for default **https://influxdb** and this didn't work. The dir that you need inside is the name of the service on the docker network: **influxdb** on this case.